### PR TITLE
chore: Add versioning to Cargo deps

### DIFF
--- a/confidence-cloudflare-resolver/Cargo.toml
+++ b/confidence-cloudflare-resolver/Cargo.toml
@@ -22,7 +22,7 @@ ignored = ["getrandom"]
 
 [dependencies]
 bytes = "1.10.1"
-confidence_resolver = { path = "../confidence-resolver" }
+confidence_resolver = { path = "../confidence-resolver", version = "0.1.0" }
 getrandom = { version = "0.3.3", features = ["wasm_js"] }
 worker = { version= "0.6.1", features=['queue'] }
 base64 = "0.22.1"

--- a/wasm/rust-guest/Cargo.toml
+++ b/wasm/rust-guest/Cargo.toml
@@ -8,8 +8,8 @@ name = "rust_guest"
 crate-type = ["cdylib"]  # This is required for WASM
 
 [dependencies]
-wasm-msg = { path = "../../wasm-msg" }
-confidence_resolver = { path = "../../confidence-resolver", default-features = false }
+wasm-msg = { path = "../../wasm-msg", version = "0.1.0" }
+confidence_resolver = { path = "../../confidence-resolver", version = "0.1.0", default-features = false }
 rand = { version = "0.9.1", default-features = false, features = ["alloc", "small_rng" ]}
 prost = { version = "0.12", default-features = false }
 prost-types = { version = "0.12", default-features = false }


### PR DESCRIPTION
This should make the changelogs from release please more descriptive, currently:

<img width="1017" height="607" alt="Screenshot 2025-09-05 at 09 25 02" src="https://github.com/user-attachments/assets/69e2af38-afd5-4a9b-9eda-a43ba11b69ad" />

`rust-guest` new version will use the updated core resolver, but the `Dependencies` section (and Changelog) are not reporting that