### PR TITLE
fix: various memory issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
- "cfg-if 1.0.3",
+ "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
@@ -150,12 +150,6 @@ checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
 dependencies = [
  "shlex",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -232,7 +226,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
- "cfg-if 1.0.3",
+ "cfg-if",
 ]
 
 [[package]]
@@ -407,7 +401,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
- "cfg-if 1.0.3",
+ "cfg-if",
  "js-sys",
  "libc",
  "r-efi",
@@ -614,7 +608,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.3",
+ "cfg-if",
  "libc",
 ]
 
@@ -716,12 +710,6 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
-
-[[package]]
-name = "memory_units"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "miniz_oxide"
@@ -1178,7 +1166,6 @@ dependencies = [
  "prost-types 0.12.6",
  "rand 0.9.2",
  "wasm-msg",
- "wee_alloc",
 ]
 
 [[package]]
@@ -1503,7 +1490,7 @@ version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
- "cfg-if 1.0.3",
+ "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -1529,7 +1516,7 @@ version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
- "cfg-if 1.0.3",
+ "cfg-if",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -1598,18 +1585,6 @@ checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "wee_alloc"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "memory_units",
- "winapi",
 ]
 
 [[package]]
@@ -1926,7 +1901,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622487961193b4421cc0b1eee3a158164c958a1bd0731ff535e2c4a5dd2af30f"
 dependencies = [
- "cfg-if 1.0.3",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",

--- a/wasm/go-host/resolver_api.go
+++ b/wasm/go-host/resolver_api.go
@@ -269,7 +269,9 @@ func (r *ResolverApi) consume(addr uint32) []byte {
 	length := binary.LittleEndian.Uint32(lenBytes) - 4
 
 	// Read data
-	data, _ := memory.Read(addr, length)
+	view, _ := memory.Read(addr, length)
+	// make a copy before freeing
+	data := append([]byte(nil), view...)
 
 	// Free memory
 	ctx := context.Background()

--- a/wasm/node-host/src/wasm-msg.ts
+++ b/wasm/node-host/src/wasm-msg.ts
@@ -122,7 +122,7 @@ export class ApiBuilder<T = {}> {
 
   private consume<T>(ptr:number, codec:Codec<T>): T {
     const data = this.viewBuffer(ptr);
-    const res = codec.decode(data);
+    const res = codec.decode(data.slice());
     this.free(ptr);
     return res;
   }

--- a/wasm/rust-guest/Cargo.toml
+++ b/wasm/rust-guest/Cargo.toml
@@ -15,7 +15,6 @@ prost = { version = "0.12", default-features = false }
 prost-types = { version = "0.12", default-features = false }
 # TODO re-export Bytes
 bytes = { version = "1.4.0", default-features = false }
-wee_alloc = "0.4"
 arc-swap = "1.7.1"
 
 [build-dependencies]

--- a/wasm/rust-guest/src/lib.rs
+++ b/wasm/rust-guest/src/lib.rs
@@ -132,7 +132,7 @@ impl Host for WasmHost {
         client: &Client,
         sdk: &Option<Sdk>,
     ) {
-        let _ = LOGGER.log_resolve(
+        LOGGER.log_resolve(
             resolve_id,
             evaluation_context,
             &client.client_credential_name,
@@ -147,7 +147,7 @@ impl Host for WasmHost {
         client: &Client,
         sdk: &Option<Sdk>,
     ) {
-        let _ = LOGGER.log_assigns(resolve_id, evaluation_context, assigned_flags, client, sdk);
+        LOGGER.log_assigns(resolve_id, evaluation_context, assigned_flags, client, sdk);
     }
 
     fn encrypt_resolve_token(token_data: &[u8], _encryption_key: &[u8]) -> Result<Vec<u8>, String> {
@@ -205,7 +205,7 @@ wasm_msg_guest! {
         Ok((&resolve_result.resolved_value).into())
     }
     fn flush_logs(_request:Void) -> WasmResult<WriteFlagLogsRequest> {
-        LOGGER.checkpoint().map_err(|e| e.into())
+        Ok(LOGGER.checkpoint())
     }
 
 }

--- a/wasm/rust-guest/src/lib.rs
+++ b/wasm/rust-guest/src/lib.rs
@@ -6,9 +6,6 @@ use arc_swap::ArcSwapOption;
 use bytes::Bytes;
 use prost::Message;
 
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-
 use confidence_resolver::proto::confidence::flags::resolver::v1::{
     ResolveWithStickyRequest, WriteFlagLogsRequest,
 };


### PR DESCRIPTION
The allocator we were using (wee-alloc) is old, unmaintained and has memory leaks. This PR switches to the default wasm32-unkown-unkown std allocator. The switch strangely broke the JS and GO test apps. It turned out that what we thought were commands to read from a buffer, were in reality views into the underlying memory which we subsequently freed! The new allocator must be more aggressively reusing or zeroing the memory which helped uncover these bugs. 